### PR TITLE
Fix lib/smtpd.py utf-8 problem

### DIFF
--- a/Lib/smtpd.py
+++ b/Lib/smtpd.py
@@ -102,6 +102,7 @@ EMPTYSTRING = ''
 COMMASPACE = ', '
 DATA_SIZE_DEFAULT = 33554432
 
+EMPTYBINARY = b''   # fix 0 - binary joiner
 
 def usage(code, msg=''):
     print(__doc__ % globals(), file=sys.stderr)
@@ -286,11 +287,11 @@ class SMTPChannel(asynchat.async_chat):
             return
         elif limit:
             self.num_bytes += len(data)
-        self.received_lines.append(str(data, "utf-8"))
+        self.received_lines.append(data)    # fix 1 - recv raw data, no utf-8 decode   
 
     # Implementation of base class abstract method
     def found_terminator(self):
-        line = EMPTYSTRING.join(self.received_lines)
+        line = EMPTYBINARY.join(self.received_lines).decode('utf8', 'ignore')   # fix 2 - decode joined utf-8 data
         print('Data:', repr(line), file=DEBUGSTREAM)
         self.received_lines = []
         if self.smtp_state == self.COMMAND:


### PR DESCRIPTION
Fix utf-8 bug, when symbol byte chain splits on 2 tcp-packets:

error: uncaptured python exception, closing channel <smtpd.SMTPChannel connected x.x.x.x:pp at {addr}> (<class 'UnicodeDecodeError'>:'utf-8' codec can't decode byte 0xd0 in position 1474: unexpected end of data [/usr/lib/python3.3/asyncore.py|read|83] [/usr/lib/python3.3/asyncore.py|handle_read_event|441] [/usr/lib/python3.3/asynchat.py|handle_read|178] [/usr/lib/python3.3/smtpd.py|collect_incoming_data|289])
